### PR TITLE
feat(pwa): add service worker registration for installability [ID3]

### DIFF
--- a/apps/web/public/sw.js
+++ b/apps/web/public/sw.js
@@ -1,0 +1,40 @@
+const CACHE_NAME = 'hidden-friend-v1';
+const ASSETS = [
+  '/',
+  '/index.html',
+  '/manifest.webmanifest',
+  '/favicon.ico'
+];
+
+self.addEventListener('install', (event) => {
+  event.waitUntil(
+    caches.open(CACHE_NAME).then((cache) => {
+      return cache.addAll(ASSETS).catch(err => console.warn('Cache warning:', err));
+    })
+  );
+  self.skipWaiting();
+});
+
+self.addEventListener('activate', (event) => {
+  event.waitUntil(
+    caches.keys().then((keys) => {
+      return Promise.all(
+        keys.map((key) => {
+          if (key !== CACHE_NAME) {
+            return caches.delete(key);
+          }
+        })
+      );
+    })
+  );
+  self.clients.claim();
+});
+
+self.addEventListener('fetch', (event) => {
+  // Let the browser handle standard requests; must intercept fetch to satisfy PWA criteria
+  event.respondWith(
+    caches.match(event.request).then((cachedResponse) => {
+      return cachedResponse || fetch(event.request);
+    })
+  );
+});

--- a/apps/web/src/index.html
+++ b/apps/web/src/index.html
@@ -15,5 +15,15 @@
   </head>
   <body>
     <app-root></app-root>
+    <script>
+      if ('serviceWorker' in navigator) {
+        window.addEventListener('load', () => {
+          navigator.serviceWorker.register('/sw.js')
+            .then(reg => console.log('Service Worker registrado:', reg.scope))
+            .catch(err => console.log('Erro ao registrar Service Worker:', err));
+        });
+      }
+    </script>
   </body>
 </html>
+


### PR DESCRIPTION
Agora que adicionamos um Service Worker (sw.js) leve e o registramos no index.html, o navegador finalmente reconhecerá a aplicação como um PWA instalável.